### PR TITLE
Fix replacement to support multiple components

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ export default function angular(options = {}) {
       let match;
       let start, end, replacement;
 
-      while ((match = componentRegex.exec(magicString)) !== null) {
+      while ((match = componentRegex.exec(source)) !== null) {
         start = match.index;
         end = start + match[0].length;
 


### PR DESCRIPTION
When one file has multiple @Component() declarations, the MagicString gets modified multiple times.

The way the MagicString works, though, the indices are all based on the _original_ string offsets. So when the componentRegex searches the modified string, it comes up with offsets outside of the range of the original string, which throws an error.

The simple fix is to search the _source_ string instead.
