### PR TITLE
Ignore js comments

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import path from 'path';
 import MagicString from 'magic-string';
 import { createFilter } from 'rollup-pluginutils';
 
+const jsCommentsRegex = /\/\*[\s\S]*?\*\/|([^:]|^)\/\/.*$/gm;
 const componentRegex = /@Component\(\s?{([\s\S]*)}\s?\)$/gm;
 const templateUrlRegex = /templateUrl\s*:(.*)/g;
 const styleUrlsRegex = /styleUrls\s*:(\s*\[[\s\S]*?\])/g;
@@ -31,6 +32,8 @@ export default function angular(options = {}) {
     name: 'angular',
     transform(source, map) {
       if (!filter(map)) return;
+
+      source = source.replace(jsCommentsRegex, '');
 
       const magicString = new MagicString(source);
       const dir = path.parse(map).dir;


### PR DESCRIPTION
We were facing the problem that example @Component definitions in javascript comments of dependency projects were processed by rollup-plugin-angular. Since they were just examples, the paths could not be resolved and broke our build.

This change removes all js comments from source before processing to avoid interpretation of comment contents.