### PR TITLE
processFilename option: passes filename to preprocessor instead of content

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "Felix Itzenplitz",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cebor/rollup-plugin-angular.git"
+    "url": "https://github.com/partap/rollup-plugin-angular.git"
   },
   "license": "MIT",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "Felix Itzenplitz",
   "repository": {
     "type": "git",
-    "url": "https://github.com/partap/rollup-plugin-angular.git"
+    "url": "https://github.com/cebor/rollup-plugin-angular.git"
   },
   "license": "MIT",
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import path from 'path';
 import MagicString from 'magic-string';
 import { createFilter } from 'rollup-pluginutils';
 
+const moduleIdRegex = /moduleId\s*:(.*)/g;
 const componentRegex = /@Component\(\s?{([\s\S]*)}\s?\)$/gm;
 const templateUrlRegex = /templateUrl\s*:(.*)/g;
 const styleUrlsRegex = /styleUrls\s*:(\s*\[[\s\S]*?\])/g;
@@ -54,6 +55,10 @@ export default function angular(options = {}) {
           .replace(styleUrlsRegex, function (match, urls) {
             hasReplacements = true;
             return 'styles:' + insertText(urls, dir, options.preprocessors.style, options.processFilename);
+          })
+          .replace(moduleIdRegex, function (match, moduleId) {
+            hasReplacements = true;
+            return '';
           });
 
         if (hasReplacements) magicString.overwrite(start, end, replacement);

--- a/src/index.js
+++ b/src/index.js
@@ -9,9 +9,12 @@ const templateUrlRegex = /templateUrl\s*:(.*)/g;
 const styleUrlsRegex = /styleUrls\s*:(\s*\[[\s\S]*?\])/g;
 const stringRegex = /(['"])((?:[^\\]\\\1|.)*?)\1/g;
 
-function insertText(str, dir, preprocessor = res => res) {
+function insertText(str, dir, preprocessor = res => res, processFilename = false) {
   return str.replace(stringRegex, function (match, quote, url) {
     const includePath = path.join(dir, url);
+    if (processFilename) {
+      return '`' + preprocessor(includePath) + '`';
+    }
     const text = fs.readFileSync(includePath).toString();
     return '`' + preprocessor(text, includePath) + '`';
   });
@@ -46,11 +49,11 @@ export default function angular(options = {}) {
         replacement = match[0]
           .replace(templateUrlRegex, function (match, url) {
             hasReplacements = true;
-            return 'template:' + insertText(url, dir, options.preprocessors.template);
+            return 'template:' + insertText(url, dir, options.preprocessors.template, options.processFilename);
           })
           .replace(styleUrlsRegex, function (match, urls) {
             hasReplacements = true;
-            return 'styles:' + insertText(urls, dir, options.preprocessors.style);
+            return 'styles:' + insertText(urls, dir, options.preprocessors.style, options.processFilename);
           });
 
         if (hasReplacements) magicString.overwrite(start, end, replacement);


### PR DESCRIPTION
I wanted to use this plugin, but my html and css files are generated by pug and sass, so when rollup comes across my component decoration, the files do not yet exist.  

One possible workaround would be to run pug and sass transforms on my project before running rollup, as I do in development mode, but that would necessitate generating files in my source directory for the plugin to access.  I didn't want that, so I made this small change for myself.  Maybe others will find it useful...

If the plugin is passed the new option `{ processFilename: true }`, then the plugin will not attempt to open the file  and pass the content into the preprocessor function.  Instead, it simply passes the filename as the only argument.

I thought about passing a `null` or empty string as the first argument to the preprocessor, just to keep the function signature identical, but decided against it for simplicity... you're welcome to change that if you like.

### Example:
```
// my-thingy.component.ts
...
@Component({
  moduleId: module.id,
  selector: 'myThingy',
  templateUrl: 'my-thingy.component.html',
  styleUrls: ['my-thingy.component.css'],
})
...
```
My `source` directory contains `my-thingy.component.pug` and `my-thingy.component.sass` alongside `my-thingy.component.ts`. In development mode, these files are transpiled into `my-thingy.component.html` and `my-thingy.component.css` in the corresponding `public` directory.

Now I can just transpile and include them inline:
```
// rollup.config.js

  ...
  plugins: [
    angular({
      processFilename: true,
      preprocessors: {
        template: filename => {
          var pugfile = filename.replace(/\.html$/, '.pug');
          return pug.renderFile(pugfile);
        },
        style: filename => {
          var sassfile = filename.replace(/\.css$/, '.sass');
          var result = sass.renderSync({file: sassfile, indentedSyntax: true});
          return result.css.toString()         
        }
      }
    }),
  ...
```

